### PR TITLE
Add tests to assert correct behaviour ...

### DIFF
--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,426 @@
+package events
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestStartEventSwitch(t *testing.T) {
+	evsw := NewEventSwitch()
+	// calls over tendermint/go-common.BaseService
+	started, err := evsw.Start()
+	if started != true {
+		t.Fatalf("Failed to start EventSwitch, error: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("Started with error: %v", err)
+	}
+}
+
+func TestAddListenerForEvent(t *testing.T) {
+	evsw := NewEventSwitch()
+	started, err := evsw.Start()
+	if started == false || err != nil {
+		t.Errorf("Failed to start EventSwitch, error: %v", err)
+	}
+	messages := make(chan EventData)
+	evsw.AddListenerForEvent("listener", "event",
+		func (data EventData) {
+			messages <- data
+		})
+	go evsw.FireEvent("event", "data")
+	received := <-messages
+	if received != "data" {
+		t.Errorf("Message received does not match: %v", received)
+	}
+}
+
+func TestAddListenerForMultipleEvents(t *testing.T) {
+	evsw := NewEventSwitch()
+	started, err := evsw.Start()
+	if started == false || err != nil {
+		t.Errorf("Failed to start EventSwitch, error: %v", err)
+	}
+	doneSum := make(chan uint64)
+	doneSending := make(chan uint64)
+	numbers := make(chan uint64, 4)
+	// subscribe one listener for one event
+	evsw.AddListenerForEvent("listener", "event",
+		func (data EventData) {
+			numbers <- data.(uint64)
+		})
+	// collect received events
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers
+			sum += j
+			if !more {
+				doneSum <- sum
+				close(doneSum)
+				return
+			}
+		}
+	}()
+	// go fire events
+	go func() {
+		var sentsum uint64 = 0
+		for i := uint64(1); i<= uint64(1000); i++ {
+			sentsum += i
+			evsw.FireEvent("event", i)
+		}
+		close(numbers)
+		doneSending <- sentsum
+		close(doneSending)
+	}()
+	checksum := <-doneSending
+	eventsum := <-doneSum
+  if checksum != eventsum {
+		t.Errorf("Not all messages sent were received.\n")
+	}
+}
+
+func TestAddListenerForDifferentEvents(t *testing.T) {
+	evsw := NewEventSwitch()
+	started, err := evsw.Start()
+	if started == false || err != nil {
+		t.Errorf("Failed to start EventSwitch, error: %v", err)
+	}
+	doneSum := make(chan uint64)
+	doneSending1 := make(chan uint64)
+	doneSending2 := make(chan uint64)
+	doneSending3 := make(chan uint64)
+	numbers := make(chan uint64, 4)
+	// subscribe one listener to three events
+	evsw.AddListenerForEvent("listener", "event1",
+		func (data EventData) {
+			numbers <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener", "event2",
+		func (data EventData) {
+			numbers <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener", "event3",
+		func (data EventData) {
+			numbers <- data.(uint64)
+		})
+	// collect received events
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers
+			sum += j
+			if !more {
+				doneSum <- sum
+				close(doneSum)
+				return
+			}
+		}
+	}()
+	// go fire events
+	sendEvents := func(event string, doneChan chan uint64) {
+		var sentsum uint64 = 0
+		for i := uint64(1); i<= uint64(1000) ; i++ {
+			sentsum += i
+			evsw.FireEvent(event, i)
+		}
+		doneChan <- sentsum
+		close(doneChan)
+		return
+	}
+	go sendEvents("event1", doneSending1)
+	go sendEvents("event2", doneSending2)
+	go sendEvents("event3", doneSending3)
+	var checksum uint64 = 0
+	checksum += <-doneSending1
+	checksum += <-doneSending2
+	checksum += <-doneSending3
+	close(numbers)
+	eventsum := <-doneSum
+  if checksum != eventsum {
+		t.Errorf("Not all messages sent were received.\n")
+	}
+}
+
+func TestAddDifferentListenerForDifferentEvents(t *testing.T) {
+	evsw := NewEventSwitch()
+	started, err := evsw.Start()
+	if started == false || err != nil {
+		t.Errorf("Failed to start EventSwitch, error: %v", err)
+	}
+	doneSum1 := make(chan uint64)
+	doneSum2 := make(chan uint64)
+	doneSending1 := make(chan uint64)
+	doneSending2 := make(chan uint64)
+	doneSending3 := make(chan uint64)
+	numbers1 := make(chan uint64, 4)
+	numbers2 := make(chan uint64, 4)
+	// subscribe two listener to three events
+	evsw.AddListenerForEvent("listener1", "event1",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener1", "event2",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener1", "event3",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener2", "event2",
+		func (data EventData) {
+			numbers2 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener2", "event3",
+		func (data EventData) {
+			numbers2 <- data.(uint64)
+		})
+	// collect received events for listener1
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers1
+			sum += j
+			if !more {
+				doneSum1 <- sum
+				close(doneSum1)
+				return
+			}
+		}
+	}()
+	// collect received events for listener2
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers2
+			sum += j
+			if !more {
+				doneSum2 <- sum
+				close(doneSum2)
+				return
+			}
+		}
+	}()
+
+	// go fire events
+	sendEvents := func(event string, doneChan chan uint64, offset uint64) {
+		var sentsum uint64 = 0
+		for i := offset; i<= offset + uint64(999) ; i++ {
+			sentsum += i
+			evsw.FireEvent(event, i)
+		}
+		doneChan <- sentsum
+		close(doneChan)
+		return
+	}
+	go sendEvents("event1", doneSending1, uint64(1))
+	go sendEvents("event2", doneSending2, uint64(1001))
+	go sendEvents("event3", doneSending3, uint64(2001))
+	checksumevent1 := <-doneSending1
+	checksumevent2 := <-doneSending2
+	checksumevent3 := <-doneSending3
+	checksum1 := checksumevent1 + checksumevent2 + checksumevent3
+	checksum2 := checksumevent2 + checksumevent3
+	close(numbers1)
+	close(numbers2)
+	eventsum1 := <-doneSum1
+	eventsum2 := <-doneSum2
+  if checksum1 != eventsum1 ||
+	 	checksum2 != eventsum2 {
+		t.Errorf("Not all messages sent were received for different listeners to different events.\n")
+	}
+}
+
+func TestAddAndRemoveListenerForEvents(t *testing.T) {
+	evsw := NewEventSwitch()
+	started, err := evsw.Start()
+	if started == false || err != nil {
+		t.Errorf("Failed to start EventSwitch, error: %v", err)
+	}
+	doneSum1 := make(chan uint64)
+	doneSum2 := make(chan uint64)
+	doneSending1 := make(chan uint64)
+	doneSending2 := make(chan uint64)
+	numbers1 := make(chan uint64, 4)
+	numbers2 := make(chan uint64, 4)
+	// subscribe two listener to three events
+	evsw.AddListenerForEvent("listener", "event1",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener", "event2",
+		func (data EventData) {
+			numbers2 <- data.(uint64)
+		})
+	// collect received events for event1
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers1
+			sum += j
+			if !more {
+				doneSum1 <- sum
+				close(doneSum1)
+				return
+			}
+		}
+	}()
+	// collect received events for event2
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers2
+			sum += j
+			if !more {
+				doneSum2 <- sum
+				close(doneSum2)
+				return
+			}
+		}
+	}()
+	// go fire events
+	sendEvents := func(event string, doneChan chan uint64, offset uint64) {
+		var sentsum uint64 = 0
+		for i := offset; i<= offset + uint64(999) ; i++ {
+			sentsum += i
+			evsw.FireEvent(event, i)
+		}
+		doneChan <- sentsum
+		close(doneChan)
+		return
+	}
+	go sendEvents("event1", doneSending1, uint64(1))
+	checksumevent1 := <-doneSending1
+	// after sending all event1, unsubscribe for all events
+	evsw.RemoveListener("listener")
+	go sendEvents("event2", doneSending2, uint64(1001))
+	checksumevent2 := <-doneSending2
+	close(numbers1)
+	close(numbers2)
+	eventsum1 := <-doneSum1
+	eventsum2 := <-doneSum2
+  if checksumevent1 != eventsum1 ||
+	 	checksumevent2 != uint64(1500500) ||
+		eventsum2 != uint64(0) {
+		t.Errorf("Not all messages sent were received or unsubscription did not register.\n")
+	}
+}
+
+func TestRemoveListenersAsync(t *testing.T) {
+	evsw := NewEventSwitch()
+	started, err := evsw.Start()
+	if started == false || err != nil {
+		t.Errorf("Failed to start EventSwitch, error: %v", err)
+	}
+	doneSum1 := make(chan uint64)
+	doneSum2 := make(chan uint64)
+	doneSending1 := make(chan uint64)
+	doneSending2 := make(chan uint64)
+	doneSending3 := make(chan uint64)
+	numbers1 := make(chan uint64, 4)
+	numbers2 := make(chan uint64, 4)
+	// subscribe two listener to three events
+	evsw.AddListenerForEvent("listener1", "event1",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener1", "event2",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener1", "event3",
+		func (data EventData) {
+			numbers1 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener2", "event1",
+		func (data EventData) {
+			numbers2 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener2", "event2",
+		func (data EventData) {
+			numbers2 <- data.(uint64)
+		})
+	evsw.AddListenerForEvent("listener2", "event3",
+		func (data EventData) {
+			numbers2 <- data.(uint64)
+		})
+	// collect received events for event1
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers1
+			sum += j
+			if !more {
+				doneSum1 <- sum
+				close(doneSum1)
+				return
+			}
+		}
+	}()
+	// collect received events for event2
+	go func() {
+		var sum uint64 = 0
+		for {
+			j, more := <-numbers2
+			sum += j
+			if !more {
+				doneSum2 <- sum
+				close(doneSum2)
+				return
+			}
+		}
+	}()
+	// go fire events
+	sendEvents := func(event string, doneChan chan uint64, offset uint64) {
+		var sentsum uint64 = 0
+		for i := offset; i<= offset + uint64(999) ; i++ {
+			sentsum += i
+			evsw.FireEvent(event, i)
+		}
+		doneChan <- sentsum
+		close(doneChan)
+		return
+	}
+	addListenersStress := func() {
+		s1 := rand.NewSource(time.Now().UnixNano())
+		r1 := rand.New(s1)
+		for k := uint16(0); k < 2000; k++ {
+			listenerNumber := r1.Intn(100) + 3
+			eventNumber := r1.Intn(3) + 1
+			go evsw.AddListenerForEvent(fmt.Sprintf("listener%v", listenerNumber),
+				fmt.Sprintf("event%v", eventNumber),
+				func (_ EventData) {})
+		}
+	}
+	removeListenersStress := func() {
+		s2 := rand.NewSource(time.Now().UnixNano())
+		r2 := rand.New(s2)
+		for k := uint16(0); k < 1000; k++ {
+			listenerNumber := r2.Intn(100) + 3
+			eventNumber := r2.Intn(3) + 1
+			go evsw.RemoveListenerForEvent(fmt.Sprintf("listener%v", listenerNumber),
+				fmt.Sprintf("event%v", eventNumber))
+		}
+	}
+	go addListenersStress()
+	go sendEvents("event1", doneSending1, uint64(1))
+	go removeListenersStress()
+	go sendEvents("event2", doneSending2, uint64(1001))
+	go sendEvents("event3", doneSending3, uint64(2001))
+	checksumevent1 := <-doneSending1
+	checksumevent2 := <-doneSending2
+	checksumevent3 := <-doneSending3
+	checksum1 := checksumevent1 + checksumevent2 + checksumevent3
+	checksum2 := checksumevent1 + checksumevent2 + checksumevent3
+	close(numbers1)
+	close(numbers2)
+	eventsum1 := <-doneSum1
+	eventsum2 := <-doneSum2
+  if checksum1 != eventsum1 ||
+	 	checksum2 != eventsum2 {
+		t.Errorf("Not all messages sent were received.\n")
+	}
+}

--- a/events_test.go
+++ b/events_test.go
@@ -27,7 +27,7 @@ func TestAddListenerForEvent(t *testing.T) {
 	}
 	messages := make(chan EventData)
 	evsw.AddListenerForEvent("listener", "event",
-		func (data EventData) {
+		func(data EventData) {
 			messages <- data
 		})
 	go evsw.FireEvent("event", "data")
@@ -48,7 +48,7 @@ func TestAddListenerForMultipleEvents(t *testing.T) {
 	numbers := make(chan uint64, 4)
 	// subscribe one listener for one event
 	evsw.AddListenerForEvent("listener", "event",
-		func (data EventData) {
+		func(data EventData) {
 			numbers <- data.(uint64)
 		})
 	// collect received events
@@ -66,18 +66,18 @@ func TestAddListenerForMultipleEvents(t *testing.T) {
 	}()
 	// go fire events
 	go func() {
-		var sentsum uint64 = 0
-		for i := uint64(1); i<= uint64(1000); i++ {
-			sentsum += i
+		var sentSum uint64 = 0
+		for i := uint64(1); i <= uint64(1000); i++ {
+			sentSum += i
 			evsw.FireEvent("event", i)
 		}
 		close(numbers)
-		doneSending <- sentsum
+		doneSending <- sentSum
 		close(doneSending)
 	}()
-	checksum := <-doneSending
-	eventsum := <-doneSum
-  if checksum != eventsum {
+	checkSum := <-doneSending
+	eventSum := <-doneSum
+	if checkSum != eventSum {
 		t.Errorf("Not all messages sent were received.\n")
 	}
 }
@@ -95,15 +95,15 @@ func TestAddListenerForDifferentEvents(t *testing.T) {
 	numbers := make(chan uint64, 4)
 	// subscribe one listener to three events
 	evsw.AddListenerForEvent("listener", "event1",
-		func (data EventData) {
+		func(data EventData) {
 			numbers <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener", "event2",
-		func (data EventData) {
+		func(data EventData) {
 			numbers <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener", "event3",
-		func (data EventData) {
+		func(data EventData) {
 			numbers <- data.(uint64)
 		})
 	// collect received events
@@ -121,25 +121,25 @@ func TestAddListenerForDifferentEvents(t *testing.T) {
 	}()
 	// go fire events
 	sendEvents := func(event string, doneChan chan uint64) {
-		var sentsum uint64 = 0
-		for i := uint64(1); i<= uint64(1000) ; i++ {
-			sentsum += i
+		var sentSum uint64 = 0
+		for i := uint64(1); i <= uint64(1000); i++ {
+			sentSum += i
 			evsw.FireEvent(event, i)
 		}
-		doneChan <- sentsum
+		doneChan <- sentSum
 		close(doneChan)
 		return
 	}
 	go sendEvents("event1", doneSending1)
 	go sendEvents("event2", doneSending2)
 	go sendEvents("event3", doneSending3)
-	var checksum uint64 = 0
-	checksum += <-doneSending1
-	checksum += <-doneSending2
-	checksum += <-doneSending3
+	var checkSum uint64 = 0
+	checkSum += <-doneSending1
+	checkSum += <-doneSending2
+	checkSum += <-doneSending3
 	close(numbers)
-	eventsum := <-doneSum
-  if checksum != eventsum {
+	eventSum := <-doneSum
+	if checkSum != eventSum {
 		t.Errorf("Not all messages sent were received.\n")
 	}
 }
@@ -159,23 +159,23 @@ func TestAddDifferentListenerForDifferentEvents(t *testing.T) {
 	numbers2 := make(chan uint64, 4)
 	// subscribe two listener to three events
 	evsw.AddListenerForEvent("listener1", "event1",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener1", "event2",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener1", "event3",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener2", "event2",
-		func (data EventData) {
+		func(data EventData) {
 			numbers2 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener2", "event3",
-		func (data EventData) {
+		func(data EventData) {
 			numbers2 <- data.(uint64)
 		})
 	// collect received events for listener1
@@ -207,29 +207,29 @@ func TestAddDifferentListenerForDifferentEvents(t *testing.T) {
 
 	// go fire events
 	sendEvents := func(event string, doneChan chan uint64, offset uint64) {
-		var sentsum uint64 = 0
-		for i := offset; i<= offset + uint64(999) ; i++ {
-			sentsum += i
+		var sentSum uint64 = 0
+		for i := offset; i <= offset+uint64(999); i++ {
+			sentSum += i
 			evsw.FireEvent(event, i)
 		}
-		doneChan <- sentsum
+		doneChan <- sentSum
 		close(doneChan)
 		return
 	}
 	go sendEvents("event1", doneSending1, uint64(1))
 	go sendEvents("event2", doneSending2, uint64(1001))
 	go sendEvents("event3", doneSending3, uint64(2001))
-	checksumevent1 := <-doneSending1
-	checksumevent2 := <-doneSending2
-	checksumevent3 := <-doneSending3
-	checksum1 := checksumevent1 + checksumevent2 + checksumevent3
-	checksum2 := checksumevent2 + checksumevent3
+	checkSumEvent1 := <-doneSending1
+	checkSumEvent2 := <-doneSending2
+	checkSumEvent3 := <-doneSending3
+	checkSum1 := checkSumEvent1 + checkSumEvent2 + checkSumEvent3
+	checkSum2 := checkSumEvent2 + checkSumEvent3
 	close(numbers1)
 	close(numbers2)
-	eventsum1 := <-doneSum1
-	eventsum2 := <-doneSum2
-  if checksum1 != eventsum1 ||
-	 	checksum2 != eventsum2 {
+	eventSum1 := <-doneSum1
+	eventSum2 := <-doneSum2
+	if checkSum1 != eventSum1 ||
+		checkSum2 != eventSum2 {
 		t.Errorf("Not all messages sent were received for different listeners to different events.\n")
 	}
 }
@@ -248,11 +248,11 @@ func TestAddAndRemoveListenerForEvents(t *testing.T) {
 	numbers2 := make(chan uint64, 4)
 	// subscribe two listener to three events
 	evsw.AddListenerForEvent("listener", "event1",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener", "event2",
-		func (data EventData) {
+		func(data EventData) {
 			numbers2 <- data.(uint64)
 		})
 	// collect received events for event1
@@ -283,28 +283,28 @@ func TestAddAndRemoveListenerForEvents(t *testing.T) {
 	}()
 	// go fire events
 	sendEvents := func(event string, doneChan chan uint64, offset uint64) {
-		var sentsum uint64 = 0
-		for i := offset; i<= offset + uint64(999) ; i++ {
-			sentsum += i
+		var sentSum uint64 = 0
+		for i := offset; i <= offset+uint64(999); i++ {
+			sentSum += i
 			evsw.FireEvent(event, i)
 		}
-		doneChan <- sentsum
+		doneChan <- sentSum
 		close(doneChan)
 		return
 	}
 	go sendEvents("event1", doneSending1, uint64(1))
-	checksumevent1 := <-doneSending1
+	checkSumEvent1 := <-doneSending1
 	// after sending all event1, unsubscribe for all events
 	evsw.RemoveListener("listener")
 	go sendEvents("event2", doneSending2, uint64(1001))
-	checksumevent2 := <-doneSending2
+	checkSumEvent2 := <-doneSending2
 	close(numbers1)
 	close(numbers2)
-	eventsum1 := <-doneSum1
-	eventsum2 := <-doneSum2
-  if checksumevent1 != eventsum1 ||
-	 	checksumevent2 != uint64(1500500) ||
-		eventsum2 != uint64(0) {
+	eventSum1 := <-doneSum1
+	eventSum2 := <-doneSum2
+	if checkSumEvent1 != eventSum1 ||
+		checkSumEvent2 != uint64(1500500) ||
+		eventSum2 != uint64(0) {
 		t.Errorf("Not all messages sent were received or unsubscription did not register.\n")
 	}
 }
@@ -324,27 +324,27 @@ func TestRemoveListenersAsync(t *testing.T) {
 	numbers2 := make(chan uint64, 4)
 	// subscribe two listener to three events
 	evsw.AddListenerForEvent("listener1", "event1",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener1", "event2",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener1", "event3",
-		func (data EventData) {
+		func(data EventData) {
 			numbers1 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener2", "event1",
-		func (data EventData) {
+		func(data EventData) {
 			numbers2 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener2", "event2",
-		func (data EventData) {
+		func(data EventData) {
 			numbers2 <- data.(uint64)
 		})
 	evsw.AddListenerForEvent("listener2", "event3",
-		func (data EventData) {
+		func(data EventData) {
 			numbers2 <- data.(uint64)
 		})
 	// collect received events for event1
@@ -375,12 +375,12 @@ func TestRemoveListenersAsync(t *testing.T) {
 	}()
 	// go fire events
 	sendEvents := func(event string, doneChan chan uint64, offset uint64) {
-		var sentsum uint64 = 0
-		for i := offset; i<= offset + uint64(999) ; i++ {
-			sentsum += i
+		var sentSum uint64 = 0
+		for i := offset; i <= offset+uint64(999); i++ {
+			sentSum += i
 			evsw.FireEvent(event, i)
 		}
-		doneChan <- sentsum
+		doneChan <- sentSum
 		close(doneChan)
 		return
 	}
@@ -392,7 +392,7 @@ func TestRemoveListenersAsync(t *testing.T) {
 			eventNumber := r1.Intn(3) + 1
 			go evsw.AddListenerForEvent(fmt.Sprintf("listener%v", listenerNumber),
 				fmt.Sprintf("event%v", eventNumber),
-				func (_ EventData) {})
+				func(_ EventData) {})
 		}
 	}
 	removeListenersStress := func() {
@@ -408,17 +408,17 @@ func TestRemoveListenersAsync(t *testing.T) {
 	go removeListenersStress()
 	go sendEvents("event2", doneSending2, uint64(1001))
 	go sendEvents("event3", doneSending3, uint64(2001))
-	checksumevent1 := <-doneSending1
-	checksumevent2 := <-doneSending2
-	checksumevent3 := <-doneSending3
-	checksum1 := checksumevent1 + checksumevent2 + checksumevent3
-	checksum2 := checksumevent1 + checksumevent2 + checksumevent3
+	checkSumEvent1 := <-doneSending1
+	checkSumEvent2 := <-doneSending2
+	checkSumEvent3 := <-doneSending3
+	checkSum1 := checkSumEvent1 + checkSumEvent2 + checkSumEvent3
+	checkSum2 := checkSumEvent1 + checkSumEvent2 + checkSumEvent3
 	close(numbers1)
 	close(numbers2)
-	eventsum1 := <-doneSum1
-	eventsum2 := <-doneSum2
-  if checksum1 != eventsum1 ||
-	 	checksum2 != eventsum2 {
+	eventSum1 := <-doneSum1
+	eventSum2 := <-doneSum2
+	if checkSum1 != eventSum1 ||
+		checkSum2 != eventSum2 {
 		t.Errorf("Not all messages sent were received.\n")
 	}
 }

--- a/events_test.go
+++ b/events_test.go
@@ -387,7 +387,7 @@ func TestRemoveListenersAsync(t *testing.T) {
 	addListenersStress := func() {
 		s1 := rand.NewSource(time.Now().UnixNano())
 		r1 := rand.New(s1)
-		for k := uint16(0); k < 2000; k++ {
+		for k := uint16(0); k < 400; k++ {
 			listenerNumber := r1.Intn(100) + 3
 			eventNumber := r1.Intn(3) + 1
 			go evsw.AddListenerForEvent(fmt.Sprintf("listener%v", listenerNumber),
@@ -398,11 +398,9 @@ func TestRemoveListenersAsync(t *testing.T) {
 	removeListenersStress := func() {
 		s2 := rand.NewSource(time.Now().UnixNano())
 		r2 := rand.New(s2)
-		for k := uint16(0); k < 1000; k++ {
+		for k := uint16(0); k < 80; k++ {
 			listenerNumber := r2.Intn(100) + 3
-			eventNumber := r2.Intn(3) + 1
-			go evsw.RemoveListenerForEvent(fmt.Sprintf("listener%v", listenerNumber),
-				fmt.Sprintf("event%v", eventNumber))
+			go evsw.RemoveListener(fmt.Sprintf("listener%v", listenerNumber))
 		}
 	}
 	go addListenersStress()


### PR DESCRIPTION
... and attempt to reproduce potential panic on lock

This first of all offers some unit tests if so desired by tendermint; while there is no CI set up, locally these tests all pass.

The first 6 tests assert normal behaviour:
- TestStartEventSwitch
- TestAddListenerForEvent
- TestAddListenerForMultipleEvents
- TestAddListenerForDifferentEvents
- TestAddDifferentListenerForDifferentEvents
- TestAddAndRemoveListenerForEvents

The seventh test is an attempt to recreate in a reproducible manner the reported crash when removing listeners under some load
- TestRemoveListenersAsync
This test also passes, and does not seem to cause a runtime error.

It should be noted that this demonstrates:
1. that these tests assert good behaviour of go-events, and do not expose unknown bugs
2. that I have so far failed to reproduce the reported behaviour in these unit tests
It does not disprove the reported bug in https://github.com/eris-ltd/eris-db/issues/143

@ebuchman: you do not have to merge this; for the purpose of unit tests, the tests can be condensed
@dennismckinnon: I will need to move closer to the reported conditions to try to reproduce the bug.

PS: as I write this I realise that the version vendored in eris-db, where the bug was reported, is not necessarily the up-to-date version against which these test have been run.  That can be another assertion to make.